### PR TITLE
Update Node to Version 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
This PR updates the Node version used by the action to v20 as per <https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/>

This will remove the deprecation warning seen below when running the action:

> ![image](https://github.com/JorelAli/setup-elm/assets/52687/981be4bf-2a3e-4df1-8d5a-ae5ac678a293)

Closes #11